### PR TITLE
[refactor] ⚛️ 🖼️ Instafeed; NOTE: Must set API Keys in .ENV

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "js-beautify": "^1.6.12",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "react-instafeed": "^0.2.1",
+    "react-instafeed": "^0.3.2",
     "react-redux": "^5.0.4",
     "redux": "^3.6.0",
     "redux-logger": "^3.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ import About from '../src/components/About';
 import YTSearch from 'youtube-api-search';
 import VideoList from '../src/youtube/video_list';
 import VideoLightBox from '../src/youtube/video_lightbox';
-import Instafeed from 'react-instafeed';
 import Gallery from '../src/instagram/image_feed';
 const  API_KEY_YouTube = '47618d1438ca41b081944b6b2ff83125'; // YouTube API Key
 
@@ -51,9 +50,7 @@ export default class App extends React.Component {
         <Nav />
         <Hero />
         <About />
-        <Instafeed>
-            <Gallery />
-        </Instafeed>
+        <Gallery />
         <Provider store={store}>
           <Stream />
         </Provider>

--- a/src/instagram/image_feed.js
+++ b/src/instagram/image_feed.js
@@ -1,55 +1,34 @@
-import React, { Component } from 'react';
+import React from 'react';
+import Instafeed from 'react-instafeed';
 
-export default class Instafeed extends Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.state = {
-      instafeedLoaded: false
-    };
-  }
-
-  componentDidMount() {
-    this.setState({
-      instafeedLoaded: true
-    });
-  }
-
-  renderInstafeed() {
-    if (!this.state.instafeedLoaded) {
-      // 📓️ NOTE: Do not use className (React), HTML standards apply
-      // Below provided is the default as an example
-      // Anything you put here will be take precedence
-      const instafeedTemplate =
-         `<a href="{{link}}" target="_blank" class="instafeed__item">
-              <img class="instafeed__item__background" src="{{image}}" />
-          </a>`;
-      const instafeed = <Instafeed
-        userId={`${INSTAGRAM_USER_ID}`}
-        clientId={`${INSTAGRAM_CLIENT_ID}`}
-        accessToken={`${INSTAGRAM_ACCESS_TOKEN}`}
-        target='instafeed'
-        resolution='standard_resolution'
-        limit='1'
-        sortBy='most-recent'
-        ref='instafeed'
-        template={instafeedTemplate}
-        customClass={this.state.instafeedLoaded ? 'loaded' : ''}
-        />;
-      return instafeed;
-    }
-
-  }
+class InstafeedComponent extends React.Component {
 
   render() {
+    const instafeedTarget = 'instafeed';
+    const instafeedTemplate = `<a href="{{link}}" target="_blank" class="instafeed__item">
+            <img class="instafeed__item__background" src="{{image}}" />
+        </a>`;
     return (
       <div className="insta-container">
          <div className="head_title_box">
            <div className="title_name"><p>Gallery</p></div>
          </div>
-
-         <div id='instafeed'>{this.renderInstafeed()}</div>
+         <div id={instafeedTarget}>
+          <Instafeed
+            limit='5'
+            ref='instafeed'
+            resolution='standard_resolution'
+            sortBy='most-recent'
+            target={instafeedTarget}
+            template={instafeedTemplate}
+            userId={process.env.REACT_APP_INSTAGRAM_USER_ID}
+            clientId={process.env.REACT_APP_INSTAGRAM_CLIENT_ID}
+            accessToken={process.env.REACT_APP_INSTAGRAM_ACCESS_TOKEN}
+            />
+        </div>
        </div>
     )
   };
 }
+
+export default InstafeedComponent;

--- a/src/soundcloud/components/Stream/index.js
+++ b/src/soundcloud/components/Stream/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import Stream from '../Stream/presenter';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,7 +1533,7 @@ debug@2.2.0, debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.6.0:
+debug@2.6.0, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
@@ -1545,7 +1545,7 @@ debug@2.6.1:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.3, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
+debug@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
@@ -4375,6 +4375,13 @@ prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   dependencies:
     fbjs "^0.8.9"
 
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -4480,12 +4487,13 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-instafeed@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/react-instafeed/-/react-instafeed-0.2.1.tgz#4aab40d6cfc60f8a1b333b1002ac05e2d249e59d"
+react-instafeed@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/react-instafeed/-/react-instafeed-0.3.2.tgz#e3fb94a6415d9d8a2bdcaeffcd4c36f5dfcb77c9"
   dependencies:
     instafeed.js "1.4.1"
-    react "^15.4.2"
+    prop-types "^15.5.10"
+    react "^15.5.4"
 
 react-redux@^5.0.4:
   version "5.0.4"
@@ -4544,7 +4552,7 @@ react-scripts@0.9.5:
   optionalDependencies:
     fsevents "1.0.17"
 
-react@^15.4.2, react@^15.5.4:
+react@^15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
@@ -5133,7 +5141,7 @@ style-loader@0.13.1:
   dependencies:
     loader-utils "^0.2.7"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -5143,7 +5151,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
Removed:
- ./index.js
-- Reference to `react-instafeed`
-- Pull `Gallery` Component directly (not within a child element)

Refactored:
- ./src/instagram/image_feed.js
-- Redid code to match
https://github.com/JeromeFitz/react-instafeed/issues/5

Also
-- Removed reference to unused React in:
--- ./src/soundcloud/components/Stream/index.js
-- To pass lint

You need to:
- ./.env
-- Set the following keys:
=> REACT_APP_INSTAGRAM_USER_ID
=> REACT_APP_INSTAGRAM_CLIENT_ID
=> REACT_APP_INSTAGRAM_ACCESS_TOKEN